### PR TITLE
Update a2d_sentences_dataset.py

### DIFF
--- a/datasets/a2d_sentences/a2d_sentences_dataset.py
+++ b/datasets/a2d_sentences/a2d_sentences_dataset.py
@@ -116,7 +116,7 @@ class A2DSentencesDataset(Dataset):
 
         # read the instance mask:
         frame_annot_path = path.join(self.mask_annotations_dir, video_id, f'{frame_idx:05d}.h5')
-        f = h5py.File(frame_annot_path)
+        f = h5py.File(frame_annot_path, 'r')
         instances = list(f['instance'])
         instance_idx = instances.index(instance_id)  # existence was already validated during init
 


### PR DESCRIPTION
It avoids a h5py file lock issue in which multiple process cannot read the same file.
```Shell
  File "h5py/h5f.pyx", line 88, in h5py.h5f.open
OSError: Unable to open file (unable to lock file, errno = 11, error message = 'Resource temporarily unavailable')
```
```Shell
  File "h5py/h5f.pyx", line 108, in h5py.h5f.create
OSError: Unable to create file (unable to open file: name = '/path/to/dataset/text_annotations/a2d_annotation_with_instances/-AyZV127fCg/00040.h5', errno = 17, erro
r message = 'File exists', flags = 15, o_flags = c2)
```